### PR TITLE
Prevent overunn of buffer when size greater than TINYCLI_MAXBUFFER.

### DIFF
--- a/tinycli/tinycli.c
+++ b/tinycli/tinycli.c
@@ -441,7 +441,7 @@ void tinycli_putc(char c) {
 
         argc = tinycli_tokenize(buffer, argv);      // Parse command into argv and argc
         tinycli_result = tinycli_call(argc, argv);  // Try to call function
-    } else {
+    } else if(top < TINYCLI_MAXBUFFER){
         // Insert character by shifting buffer right one,
         // and saving char to the newly open index.
         for (int i = top; i > cur; i--) {

--- a/tinycli/tinycli.c
+++ b/tinycli/tinycli.c
@@ -441,7 +441,7 @@ void tinycli_putc(char c) {
 
         argc = tinycli_tokenize(buffer, argv);      // Parse command into argv and argc
         tinycli_result = tinycli_call(argc, argv);  // Try to call function
-    } else if(top < TINYCLI_MAXBUFFER){
+    } else if(top < TINYCLI_MAXBUFFER - 1){
         // Insert character by shifting buffer right one,
         // and saving char to the newly open index.
         for (int i = top; i > cur; i--) {


### PR DESCRIPTION
This fixes the issue where either a bunch of garbage characters are printed to the console or the MCU crashes with a HardFault, if the input buffer is overrun.